### PR TITLE
Use https instead of ssh as source for git repo

### DIFF
--- a/alacritty.rb
+++ b/alacritty.rb
@@ -3,7 +3,7 @@
 class Alacritty < Formula
   desc "A cross-platform, GPU-accelerated terminal emulator"
   homepage "https://github.com/jwilm/alacritty"
-  head "git@github.com:jwilm/alacritty.git", using: :git
+  head "https://github.com/jwilm/alacritty.git", using: :git
   # version "0.1.0"
   # revision 0
   # sha256 ""


### PR DESCRIPTION
This would help to avoid such problems as "git@github.com: Permission denied (publickey)".